### PR TITLE
Reduce periodic CI build to once per-month.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,7 +7,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '0 0 * * 0' # weekly
+    - cron: "0 0 1 * *" # monthly
 
 jobs:
   check:


### PR DESCRIPTION
Was weekly. Seems a bit excessive.